### PR TITLE
add github action to deploy

### DIFF
--- a/.github/workflows/bb-deploy.yml
+++ b/.github/workflows/bb-deploy.yml
@@ -1,0 +1,37 @@
+name: Test  Action
+
+on: [push]
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Show Forge version
+        run: forge --version
+        
+      - name: test_ci
+        uses: BuildBearLabs/buildbear_x_action@v1.5.0
+
+        with: 
+          network: |
+            [
+              {
+                "chainId": 1
+              }
+            ]
+
+          deploy-command: "make exe"
+          buildbear-token: "a"  
+         

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+# Makefile
+
+.PHONY: install build deploy dd
+
+install:
+	@echo "Installing dependencies..."
+	forge install
+
+build:
+	@echo "Building project..."
+	forge build
+
+deploy: install build
+	@echo "Deploying contract..."
+	forge script script/DeployMarket.s.sol --rpc-url=$(BUILDBEAR_RPC_URL) --broadcast --mnemonics="$(MNEMONIC)" --legacy --slow
+
+exe: install build deploy
+	@echo "All commands executed successfully"
+
+
+	


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for testing and deployment, as well as updates to the `Makefile` to streamline project commands. The most important changes include the creation of a new workflow file and the addition of several commands to the `Makefile`.

New GitHub Actions workflow:

* [`.github/workflows/bb-deploy.yml`](diffhunk://#diff-0a4426b78798fed1308f913d3c848a4a91a940bbc972a94c7de57fe171fb8f3dR1-R37): Added a new workflow named "Test Action" that runs on push events. It includes steps for checking out the repository, installing Foundry, showing the Forge version, and running a custom test action using BuildBearLabs.

Updates to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R23): Added commands for installing dependencies, building the project, deploying the contract, and executing all commands sequentially. These commands use Forge and a custom script for deployment.